### PR TITLE
Chores/add settlement notebook

### DIFF
--- a/notebooks/ComputeSettlementClaim.ipynb
+++ b/notebooks/ComputeSettlementClaim.ipynb
@@ -344,7 +344,7 @@
     }
    ],
    "source": [
-    "CorrMon + CorrMonExtra + JurosMoratAt1Pc + JurosMoratExtra  # should be close to 1.223.538,50"
+    "CorrMon + CorrMonExtra + JurosMoratAt1Pc + JurosMoratExtra  # should be close to 1_223_538,50"
    ]
   },
   {

--- a/notebooks/ComputeSettlementClaim.ipynb
+++ b/notebooks/ComputeSettlementClaim.ipynb
@@ -1,0 +1,731 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a1c858b-3f0c-4110-8a13-3fb841f3be93",
+   "metadata": {},
+   "source": [
+    "# Compute settlement claim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c3b5243c-9cc7-4d95-884c-1f53191f79bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = Path.cwd().parent\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "\n",
+    "from settlementcalculator.duration import months_between\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8082477-6e2f-4083-8269-84f1f44427db",
+   "metadata": {},
+   "source": [
+    "# Deliverables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92fcda39-49a3-4575-888e-a08804cb6564",
+   "metadata": {},
+   "source": [
+    "### 1) Duration "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4713f181-eb7a-4953-849b-013b93ead892",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "76"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start_date = \"2019-05-06\"\n",
+    "end_date = \"2025-10-1\"\n",
+    "months_between(start_date, end_date)\n",
+    "duration_in_months = math.floor(months_between(start_date, end_date))  # DO NOT FLOOR IN THE FINAL CALCULATION; THIS IS TO RETRACE THE PAPER CALCULATION ONLY!\n",
+    "duration_in_months"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e9aa3fd-5d55-404e-aa2d-58125f3db75c",
+   "metadata": {},
+   "source": [
+    "### 2) Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e59765a4-dd0d-4cde-9243-f5f5eb5b8219",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "636727.4069724"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "VO = 449_100 \n",
+    "VO_factor = 1.417785364\n",
+    "CorrMon = VO * VO_factor\n",
+    "CorrMon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8034c377-c192-4f27-ae5e-1ec58f068be7",
+   "metadata": {},
+   "source": [
+    "### 3) Penalty at 1% per month"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "23e1e1a3-3c94-482b-96a8-75cfbcfeed33",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "483912.8292990241"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "JurosMoratAt1Pc = CorrMon * duration_in_months / 100\n",
+    "JurosMoratAt1Pc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9eec66e4-f867-469e-ab14-bf7ad814136f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1120640.2362714242"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Subtotal = CorrMon + JurosMoratAt1Pc\n",
+    "Subtotal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9c4a7970-afcf-4f56-9c3a-6f2de75ee00e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6367.274069723964"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(CorrMon * 77 / 100 - CorrMon * 76 / 100)  # wait until 5 November for 6370 extra "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac5b6a83-8c39-4720-9d74-545bdb423538",
+   "metadata": {},
+   "source": [
+    "### 4) Additional expenses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3850c302-9912-4c8a-aadf-377eac650eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extras_sem_act = sum([4.97,\n",
+    "                      44.60,\n",
+    "                      479.50,   \n",
+    "                      4_316.47,\n",
+    "                      8_992.65,\n",
+    "                      6_324.83,\n",
+    "                      70.72,\n",
+    "                      212.16,\n",
+    "])\n",
+    "\n",
+    "CorrMonExtra = sum([\n",
+    "    12.91, 115.15, 1_056.17, 7_928.19,\n",
+    "    19_544.66, 12_199.84, 76.92, 230.76,\n",
+    "])\n",
+    "\n",
+    "JurosMoratExtra = sum([\n",
+    "    26.59, 236.05, 1_774.36, 10_306.64,\n",
+    "    32_248.68, 17_079.77, 15.38, 46.15,\n",
+    "])\n",
+    "\n",
+    "assert VO + extras_sem_act == 469_545.9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7e4e4ea2-f8e4-4cfa-8dc4-e0fa4b6b64c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VA = CorrMon + CorrMonExtra \n",
+    "JM = JurosMoratAt1Pc + JurosMoratExtra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "828c5a2a-90a0-46ac-a341-d5f3997f64e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "677892.0069724"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "VA  # should be close to 677_892.01"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4e302d94-8258-4166-b7b3-12b386366721",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "545646.4492990241"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "JM  # should be close to 545_646.49"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2603bc33-911d-490c-bf4d-8eb9a80cab7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1223538.456271424"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Subtotal = VA + JM\n",
+    "Subtotal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63104aca-8201-47e9-9bab-ace0e1773bbf",
+   "metadata": {},
+   "source": [
+    "### 5) HonSuc as 10% of `Subtotal`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "25fcb3fe-92b2-43ce-9d4d-a81ed4faf3b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "183530.76844071358"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "HonSuc = 0.15 * Subtotal  # should be close to 183_530.77\n",
+    "HonSuc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24737dcd-d9b4-4fee-81d3-ad3cceb629a4",
+   "metadata": {},
+   "source": [
+    "### 6) CorrMon + CorrMonExtra + JurosMoratAt1Pc + JurosMoratExtra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "108a3fed-5661-4f6c-94a0-8f5513a1e477",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1223538.4562714242"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "CorrMon + CorrMonExtra + JurosMoratAt1Pc + JurosMoratExtra  # should be close to 1.223.538,50"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "293b9049-bb93-43db-bdf7-e27f6bb3b54f",
+   "metadata": {},
+   "source": [
+    "### 7) Additional penalties (multa; 10% of total adjusted outstanding amount)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1ff7a1b6-92b9-48c8-9474-15474bab521b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Multa523 =  HonMulta523 = 0.1 * (VA + JM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4b4dc6a0-c8c5-4eea-b359-d0769f334c06",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "122353.84562714241"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Multa523  # should be close to 122_353.85"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2e76c9a0-9104-47f3-af7d-614695537053",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "122353.84562714241"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "HonMulta523  # should be close to 122_353.85"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "208967a0-fae6-4fb2-aeda-fa7f99ca84a0",
+   "metadata": {},
+   "source": [
+    "### 8) Total penalty and frozen amount"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c1b98501-f149-4268-81eb-29625e065352",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1651776.9159664223"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "TotalPenalty = (VA + JM) + HonSuc + HonMulta523 + Multa523  # should be close to 1_651_776.98\n",
+    "TotalPenalty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9a6788ac-5aad-48bf-8fa9-a0c44e2f1bae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "270763.12"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Frozen = 270_763.12\n",
+    "Frozen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "e46a54b8-b896-4f63-8170-c322076f9422",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1381013.7959664222"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Remaining = TotalPenalty - Frozen\n",
+    "Remaining"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4e89cd0-0178-42ea-9a88-d856189e3853",
+   "metadata": {},
+   "source": [
+    "### 9) Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0c88084c-77f3-41bc-878f-3a7ce7055f66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Total1 = 0.15 * (VA + JM) + HonSuc + HonMulta523\n",
+    "Total2 = 0.85 * (VA + JM) + Multa523"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c5dcd6f5-b0ec-4326-86fd-7a3cf53fa5a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "489415.3825085696"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Total1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "3147a6c7-fc5f-41cd-a10d-250aa79bd0fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1162361.5334578527"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Total2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "7a8ed06a-c6ce-4114-91f6-b86a034aae52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.2962962962962963"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Total1 / TotalPenalty  # fraction of Total1 w.r.t. TotalPenalty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "413a29fd-54cc-4806-8649-5f4a8d4ac713",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.7037037037037037"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Total2 / TotalPenalty  # fraction of Total2 w.r.t. TotalPenalty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "add79280-6344-4d1b-b7ba-656be4240113",
+   "metadata": {},
+   "source": [
+    "# Error analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9c4b5413-530b-4637-a0d9-d15c59ca2d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MiscalculatedTotalPenaltySergio = 1_542_647.68"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "777907ec-e1ea-4c07-9594-c215641c89b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1884.559999999823"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "InitialOffer = 1_270_000.00 + Frozen \n",
+    "ErrorFromInitialOffer = MiscalculatedTotalPenaltySergio - InitialOffer\n",
+    "ErrorFromInitialOffer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "135e378a-713c-42ce-b3d1-5085f91c69ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OffsetByInterestRate = yet to be determined on 5 November"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "8b0889de-7eb5-45d3-9ba5-06a293306ef6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1651776.9159664223"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "TotalPenalty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "95842049-6c3d-4d94-95b5-855004812d36",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1540763.12"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "InitialOffer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "e2ca12e4-ad34-4498-92da-5ee8fe3fb1d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "111013.79596642219"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "TotalPenalty - InitialOffer # + OffsetByInterestRate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2cc0952-0a65-4f39-b7c4-f5f2d80949c4",
+   "metadata": {},
+   "source": [
+    "Result: We found a additional 111013.85 (approx. 15.671 libra). The result will be increased by approx 6370 units once 77 months are passed => wait until this is the case."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/ComputeSettlementClaim.ipynb
+++ b/notebooks/ComputeSettlementClaim.ipynb
@@ -293,7 +293,7 @@
    "id": "63104aca-8201-47e9-9bab-ace0e1773bbf",
    "metadata": {},
    "source": [
-    "### 5) HonSuc as 10% of `Subtotal`"
+    "### 5) HonSuc as 15% of `Subtotal`"
    ]
   },
   {

--- a/settlementcalculator/duration.py
+++ b/settlementcalculator/duration.py
@@ -4,7 +4,7 @@ from typing import Union
 
 TimestampLike = Union[str, pd.Timestamp]
 
-def months_between(start: TimestampLike, end: TimestampLike, *, eom_rule: bool = True, allow_negative: bool = True) -> float:
+def months_between(start: TimestampLike, end: TimestampLike, *, eom_rule: bool=True, allow_negative: bool=True) -> float:
     """
     Minimal function to compute elapsed time between two dates **in decimal months** using pandas.
     

--- a/settlementcalculator/duration.py
+++ b/settlementcalculator/duration.py
@@ -10,7 +10,7 @@ def months_between(start: TimestampLike, end: TimestampLike, *, eom_rule: bool=T
     
     1. Count whole calendar months first.
     2. Add a final fractional month as `(end - anchor) / (next_anchor - anchor)`.
-    3. If `start` is month‑end and `eom_rule=True`, month steps land on month‑end.
+    3. If `start` is month-end and `eom_rule=True`, month steps land on month-end.
     """
     s = pd.to_datetime(start)
     e = pd.to_datetime(end)

--- a/settlementcalculator/duration.py
+++ b/settlementcalculator/duration.py
@@ -1,9 +1,17 @@
 import pandas as pd
 from typing import Union
 
+
 TimestampLike = Union[str, pd.Timestamp]
 
 def months_between(start: TimestampLike, end: TimestampLike, *, eom_rule: bool = True, allow_negative: bool = True) -> float:
+    """
+    Minimal function to compute elapsed time between two dates **in decimal months** using pandas.
+    
+    1. Count whole calendar months first.
+    2. Add a final fractional month as `(end - anchor) / (next_anchor - anchor)`.
+    3. If `start` is month‑end and `eom_rule=True`, month steps land on month‑end.
+    """
     s = pd.to_datetime(start)
     e = pd.to_datetime(end)
 
@@ -35,7 +43,7 @@ def months_between(start: TimestampLike, end: TimestampLike, *, eom_rule: bool =
     if next_anchor <= anchor:
         frac = 0.0
     else:
-        frac = (e - anchor) / (next_anchor - anchor)
+        frac = float((e - anchor) / (next_anchor - anchor))
         if frac < 0.0:
             frac = 0.0
         elif frac > 1.0:


### PR DESCRIPTION
This PR adds a Jupyter notebook that fully computes the settlement claim.

It provides a transparent, reproducible calculation using the existing months_between function from settlementcalculator.duration (introduced in Issue #2 and merged via PR #9).

In summary, the notebook demonstrates:
1) Calculation of the time duration (months) between 2019-05-06 and 2025-10-01 using the floored logic from months_between.

2) Application of correction and penalty factors to compute CorrMon, JurosMoratAt1Pc, HonSuc, and all subsequent values.

3) Verification of base and extra expense components.

4) Aggregation of corrected and penalised values (VA, JM) and their verification against expected reference amounts.

5) Computation of Multa523, HonMulta523, total penalty, frozen portion, and the remaining payable amount.

6) Distribution of totals between two parties, both it total amount, and fractions of the amount with respect to the total penalty.

Closes Issue #12. 